### PR TITLE
Ensure that Dockerfile_multistage builds and is runnable

### DIFF
--- a/Dockerfile_multistage
+++ b/Dockerfile_multistage
@@ -26,7 +26,7 @@ COPY . .
 RUN go mod download
 
 # Build the binary.
-RUN go build -ldflags="-w -s" -o /go/bin/certstream-server-go $GOPATH/src/certstream-server-go/cmd
+RUN go build -ldflags="-w -s" -o /go/bin/certstream-server-go $GOPATH/src/certstream-server-go/cmd/certstream-server-go/
 RUN chown -R "${USER}:${USER}" /go/bin/certstream-server-go
 
 ############################
@@ -42,7 +42,7 @@ COPY --from=builder /etc/group /etc/group
 
 # Copy our static executable.
 COPY --from=builder /go/bin/certstream-server-go /app/certstream-server-go
-COPY ./config.sample.yaml /app/config.yaml
+COPY --chown=certstreamserver:certstreamserver ./config.sample.yaml /app/config.yaml
 
 # Use an unprivileged user.
 USER certstreamserver:certstreamserver


### PR DESCRIPTION
It appears that the `go build` command was pointing to the wrong directory - the build was failing as follows:
```
...
 => ERROR [builder 7/8] RUN go build -ldflags="-w -s" -o /go/bin/certstream-server-go /go/src/certstream-server-go/cmd
------
 > [builder 7/8] RUN go build -ldflags="-w -s" -o /go/bin/certstream-server-go /go/src/certstream-server-go/cmd:
no Go files in /go/src/certstream-server-go/cmd
```

After it was fixed, the configfile had 0750 permissions - it was owned by root:root, thus certstream-server-go was failing to start.
```
config.go:49: Error while parsing yaml file: open /app/config.yaml: permission denied
```
This commit resolves this issue too.