### PR TITLE
Add support for server heartbeats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Support for non-browsers by implementing server initiated heartbeats (#39)
 ### Changed
 ### Fixed
 ### Docs

--- a/internal/web/client.go
+++ b/internal/web/client.go
@@ -36,30 +36,47 @@ func newClient(conn *websocket.Conn, subType SubscriptionType, name string, cert
 
 // Each client has a broadcastHandler that runs in the background and sends out the broadcast messages to the client.
 func (c *client) broadcastHandler() {
+	writeWait := 60 * time.Second
+	pingTicker := time.NewTicker(30 * time.Second)
+
 	defer func() {
 		log.Println("Closing broadcast handler for client:", c.conn.RemoteAddr())
+
+		pingTicker.Stop()
+
 		_ = c.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
 		_ = c.conn.WriteMessage(websocket.CloseMessage, []byte{})
 		_ = c.conn.Close()
 	}()
 
-	for message := range c.broadcastChan {
-		_ = c.conn.SetWriteDeadline(time.Now().Add(60 * time.Second))
+	for {
+		select {
+		case <-pingTicker.C:
+			log.Printf("Sent ping to %v\n", c.name)
 
-		w, err := c.conn.NextWriter(websocket.TextMessage)
-		if err != nil {
-			log.Printf("Error while getting next writer: %v\n", err)
-			return
-		}
+			_ = c.conn.SetWriteDeadline(time.Now().Add(writeWait))
 
-		_, writeErr := w.Write(message)
-		if writeErr != nil {
-			log.Printf("Error while writing: %v\n", writeErr)
-		}
+			if err := c.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				return
+			}
+		case message := <-c.broadcastChan:
+			_ = c.conn.SetWriteDeadline(time.Now().Add(writeWait))
 
-		if closeErr := w.Close(); closeErr != nil {
-			log.Printf("Error while closing: %v\n", closeErr)
-			return
+			w, err := c.conn.NextWriter(websocket.TextMessage)
+			if err != nil {
+				log.Printf("Error while getting next writer: %v\n", err)
+				return
+			}
+
+			_, writeErr := w.Write(message)
+			if writeErr != nil {
+				log.Printf("Error while writing: %v\n", writeErr)
+			}
+
+			if closeErr := w.Close(); closeErr != nil {
+				log.Printf("Error while closing: %v\n", closeErr)
+				return
+			}
 		}
 	}
 }
@@ -73,17 +90,23 @@ func (c *client) listenWebsocket() {
 		ClientHandler.unregisterClient(c)
 	}()
 
+	readWait := 65 * time.Second
+
 	c.conn.SetReadLimit(512)
-	_ = c.conn.SetReadDeadline(time.Now().Add(65 * time.Second))
+	_ = c.conn.SetReadDeadline(time.Now().Add(readWait))
 
 	defaultPingHandler := c.conn.PingHandler()
 	c.conn.SetPingHandler(func(appData string) error {
-		// Ping received - reset the ping deadline to 65 seconds
-		_ = c.conn.SetReadDeadline(time.Now().Add(65 * time.Second))
+		// Ping received - reset the deadline
+		_ = c.conn.SetReadDeadline(time.Now().Add(readWait))
 		return defaultPingHandler(appData)
 	})
 	c.conn.SetPongHandler(func(string) error {
-		// Pong received
+		// Pong received - reset the deadline
+		_ = c.conn.SetReadDeadline(time.Now().Add(readWait))
+
+		log.Printf("Received pong from %v\n", c.name)
+
 		return nil
 	})
 

--- a/internal/web/client.go
+++ b/internal/web/client.go
@@ -52,8 +52,6 @@ func (c *client) broadcastHandler() {
 	for {
 		select {
 		case <-pingTicker.C:
-			log.Printf("Sent ping to %v\n", c.name)
-
 			_ = c.conn.SetWriteDeadline(time.Now().Add(writeWait))
 
 			if err := c.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
@@ -104,8 +102,6 @@ func (c *client) listenWebsocket() {
 	c.conn.SetPongHandler(func(string) error {
 		// Pong received - reset the deadline
 		_ = c.conn.SetReadDeadline(time.Now().Add(readWait))
-
-		log.Printf("Received pong from %v\n", c.name)
 
 		return nil
 	})

--- a/internal/web/client.go
+++ b/internal/web/client.go
@@ -96,14 +96,16 @@ func (c *client) listenWebsocket() {
 	defaultPingHandler := c.conn.PingHandler()
 	c.conn.SetPingHandler(func(appData string) error {
 		// Ping received - reset the deadline
-		_ = c.conn.SetReadDeadline(time.Now().Add(readWait))
+		err := c.conn.SetReadDeadline(time.Now().Add(readWait))
+		if err != nil {
+			return err
+		}
 		return defaultPingHandler(appData)
 	})
 	c.conn.SetPongHandler(func(string) error {
 		// Pong received - reset the deadline
-		_ = c.conn.SetReadDeadline(time.Now().Add(readWait))
-
-		return nil
+		err := c.conn.SetReadDeadline(time.Now().Add(readWait))
+		return err
 	})
 
 	// Handle messages from the client


### PR DESCRIPTION
Before this change the websocket server would not have any heartbeat mechanism, this meant that unless the client proactively implements heartbeats the server would close the connection. From what I have seen most non-browser clients do not implement heartbeats (e.g [filebeat](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-websocket.html), [websocat](https://github.com/vi/websocat)), thus for those clients the connection would have been closed in 65 seconds.

The Websocket RFC [does not](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_servers#pings_and_pongs_the_heartbeat_of_websockets) set out a requirement which side should initiate heartbeats or that they are required. Most browsers have implemented heartbeats from client side, however it is not a must thus, in my opinion it is beneficial for the server to implement them, especially if the server closes connection if heartbeat is not received. This would allow to support clients which aren't browsers.