### PR TITLE
Add support for Websocket compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Support for websocket compression - disabled by default (#40)
 ### Changed
 ### Fixed
 ### Docs

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -6,6 +6,7 @@ webserver:
   domains_only_url: "/domains-only"
   cert_path: ""
   cert_key_path: ""
+  compression_enabled: false
 
 prometheus:
   enabled: true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,7 +31,7 @@ type Config struct {
 		FullURL            string `yaml:"full_url"`
 		LiteURL            string `yaml:"lite_url"`
 		DomainsOnlyURL     string `yaml:"domains_only_url"`
-		CompressionEnabled *bool  `yaml:"compression_enabled,omitempty"`
+		CompressionEnabled bool   `yaml:"compression_enabled"`
 	}
 	Prometheus struct {
 		ServerConfig        `yaml:",inline"`
@@ -133,17 +133,6 @@ func validateConfig(config Config) bool {
 	if config.Webserver.ListenPort == 0 {
 		log.Fatalln("Webhook listen port is not set")
 		return false
-	}
-
-	if config.Webserver.CompressionEnabled == nil {
-		// On one hand the Calidog certstream server does support compression by default, however
-		// the gorilla/websocket library has had issues with Safari clients.
-		// See: https://github.com/gorilla/websocket/issues/731
-		// Moreover according to gorilla/weboscket documentation, the support is experimental
-		// See: https://pkg.go.dev/github.com/gorilla/websocket#hdr-Compression_EXPERIMENTAL
-		// Thus lets default to false - i.e. disable compression by default
-		CompressionEnabled := false
-		config.Webserver.CompressionEnabled = &CompressionEnabled
 	}
 
 	if config.Webserver.FullURL == "" || !URLRegex.MatchString(config.Webserver.FullURL) {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	ClientHandler = BroadcastManager{}
-	upgrader      = websocket.Upgrader{} // use default options
+	upgrader      websocket.Upgrader
 )
 
 type WebServer struct {
@@ -248,7 +248,8 @@ func NewMetricsServer(networkIf string, port int, certPath, keyPath string) *Web
 }
 
 // NewWebsocketServer starts a new webserver and initialized it with the necessary routes.
-// It also starts the broadcaster in ClientHandler as a background job.
+// It also starts the broadcaster in ClientHandler as a background job and takes care of
+// setting up websocket.Upgrader.
 func NewWebsocketServer(networkIf string, port int, certPath, keyPath string) *WebServer {
 	server := &WebServer{
 		networkIf: networkIf,
@@ -256,6 +257,10 @@ func NewWebsocketServer(networkIf string, port int, certPath, keyPath string) *W
 		routes:    chi.NewRouter(),
 		certPath:  certPath,
 		keyPath:   keyPath,
+	}
+
+	upgrader = websocket.Upgrader{
+		EnableCompression: *config.AppConfig.Webserver.CompressionEnabled,
 	}
 
 	if config.AppConfig.Webserver.RealIP {


### PR DESCRIPTION
This PR adds the ability to enable compression for websockets. The compression is disabled by default due to the fact that it is marked as [experimental](https://pkg.go.dev/github.com/gorilla/websocket#hdr-Compression_EXPERIMENTAL) in `gorilla/websocket` and there have been [issues](https://github.com/gorilla/websocket/issues/731) with compression whenever Safari is enabled.

This PR partially addresses #30.