### PR TITLE
fix internal/config version 1.6.0 -> 1.7.0

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	AppConfig Config
-	Version   = "1.6.0"
+	Version   = "1.7.0"
 )
 
 type ServerConfig struct {


### PR DESCRIPTION
The current 1.7.0 release actually reports being version 1.6.0 when using then `-version` flag:

```shell
$ ./certstream-server-go -version
certstream-server-go v1.6.0
```

This appears to be due to the internal/config/config.go not being updated with the 1.7.0 release.

I appreciate this will appear relatively trivial, but it breaks automated build testing using simple version testers in nixpkgs, (I'm packaging certstream-server-go for inclusion in nixpkgs, which is how I discovered it).

I didn't see a CONTRIBUTING.md, so I thought for such a small fix maybe a PR was best, instead of opening an issue on it.