### PR TITLE
Docker: additional_logs adds old log

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -22,10 +22,8 @@ prometheus:
 general:
   # When you want to add logs that are not contained in the log list provided by
   # Google (https://www.gstatic.com/ct/log_list/v3/log_list.json), you can add them here.
+  # Examples: https://groups.google.com/a/chromium.org/g/ct-policy/c/lZaXMbRKtNo/m/yg2LugQcAwAJ / https://crt.sh/monitored-logs
   additional_logs:
-    - url: https://ct.googleapis.com/logs/us1/mirrors/digicert_nessie2022
-      operator: "DigiCert"
-      description: "DigiCert Nessie2022 log"
     - url: https://dodo.ct.comodo.com
       operator: "Comodo"
       description: "Comodo Dodo"


### PR DESCRIPTION
The Dockerfile just copies over the config.sample.yaml as config.yaml

https://github.com/d-Rickyy-b/certstream-server-go/blob/8d71967d327b0e93a4d9c1cec9e1c68e9f41e2b3/Dockerfile#L20

This now results in the nessie2022 mirror being in the log list besides this one no longer in the Chrome CT List and the Log is no longer reachable thus no certs to monitor.
https://issues.chromium.org/issues/41364542#comment56