### PR TITLE
Skip retired CT logs

### DIFF
--- a/internal/certificatetransparency/ct-watcher.go
+++ b/internal/certificatetransparency/ct-watcher.go
@@ -122,9 +122,14 @@ func (w *Watcher) addNewlyAvailableLogs(logList loglist3.LogList) {
 	for _, operator := range logList.Operators {
 		// Iterate over each log of the operator
 		for _, transparencyLog := range operator.Logs {
-			// Check if the log is already being watched
 			newURL := normalizeCtlogURL(transparencyLog.URL)
 
+			if transparencyLog.State.LogStatus() == loglist3.RetiredLogStatus {
+				log.Printf("Skipping retired CT log: %s\n", newURL)
+				continue
+			}
+
+			// Check if the log is already being watched
 			alreadyWatched := false
 			for _, ctWorker := range w.workers {
 				workerURL := normalizeCtlogURL(ctWorker.ctURL)


### PR DESCRIPTION
The log list contains bogus entries like `https://ct.example.com/bogus/` and `https://ct.example.com/bogus/ipng/` as well as retired logs that don't accept certificates anymore.