### PR TITLE
fix: start from current STH/checkpoint when no saved index exists

### DIFF
--- a/internal/certificatetransparency/ct-watcher.go
+++ b/internal/certificatetransparency/ct-watcher.go
@@ -375,9 +375,10 @@ func (w *worker) runStandardWorker(ctx context.Context) error {
 		return errCreatingClient
 	}
 
-	// If recovery is enabled, we start at the saved index. Otherwise, we start at the latest STH.
-	recoveryEnabled := config.AppConfig.General.Recovery.Enabled
-	if !recoveryEnabled {
+	// If recovery is enabled AND we have a saved index > 0, use it.
+	// Otherwise, fetch the current STH and start from there.
+	hasSavedIndex := config.AppConfig.General.Recovery.Enabled && w.ctIndex > 0
+	if !hasSavedIndex {
 		sth, getSTHerr := jsonClient.GetSTH(ctx)
 		if getSTHerr != nil {
 			// TODO this can happen due to a 429 error. We should retry the request
@@ -416,9 +417,10 @@ func (w *worker) runStandardWorker(ctx context.Context) error {
 func (w *worker) runTiledWorker(ctx context.Context) error {
 	hc := &http.Client{Timeout: 30 * time.Second}
 
-	// If recovery is enabled and the CT index is set, we start at the saved index. Otherwise we start at the latest checkpoint.
-	validSavedCTIndexExists := config.AppConfig.General.Recovery.Enabled && w.ctIndex >= 0
-	if !validSavedCTIndexExists {
+	// If recovery is enabled AND we have a saved index > 0, use it.
+	// Otherwise, fetch the current checkpoint and start from there.
+	hasSavedIndex := config.AppConfig.General.Recovery.Enabled && w.ctIndex > 0
+	if !hasSavedIndex {
 		checkpoint, err := FetchCheckpoint(ctx, hc, w.ctURL)
 		if err != nil {
 			log.Printf("Could not get checkpoint for '%s': %s\n", w.ctURL, err)


### PR DESCRIPTION
## Problem

When recovery is enabled but no saved index exists (first run or new log), the worker would start from index 0 and attempt to download billions of historical certificates.

In `runTiledWorker`, the condition `w.ctIndex >= 0` is always true for uint64, so it never fetched the current checkpoint.

In `runStandardWorker`, if recovery was enabled, it used whatever ctIndex was set (including 0) without checking if it was a valid saved value.

## Solution

Check `w.ctIndex > 0` to determine if a valid saved index exists. If no saved index exists, fetch the current STH/checkpoint and start from there.